### PR TITLE
Replace 'uniq' with 'unique'

### DIFF
--- a/lib/Clifford.pm6
+++ b/lib/Clifford.pm6
@@ -143,7 +143,7 @@ multi infix:<+>( Zero, $B ) is export { $B }
 #
 multi infix:<+>(MultiVector $A, MultiVector $B) returns MultiVector is export {
     MultiVector.new: canonical =>
-    gather for uniq $A.keys, $B.keys {
+    gather for unique $A.keys, $B.keys {
 	my $sum = ($A.canonical{$_}//0) + ($B.canonical{$_}//0);
 	take $_ => $sum if $sum != 0;
     }


### PR DESCRIPTION
`uniq` is deprecated and will be removed in Rakudo 2015.09.  It has been
replaced with `unique`; this change corrects this issue.